### PR TITLE
Enhance many? one?

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -290,14 +290,14 @@ module ActiveRecord
     # Returns true if there is exactly one record.
     def one?
       return super if block_given?
-      return records.one? if limit_value || loaded?
+      return records.one? if loaded?
       limited_count == 1
     end
 
     # Returns true if there is more than one record.
     def many?
       return super if block_given?
-      return records.many? if limit_value || loaded?
+      return records.many? if loaded?
       limited_count > 1
     end
 
@@ -974,7 +974,7 @@ module ActiveRecord
       end
 
       def limited_count
-        @limited_count ||= limit(2).count
+        @limited_count ||= limit_value ? count : limit(2).count
       end
   end
 end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1174,10 +1174,14 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_many_with_limits
-    posts = Post.all
+    posts_with_limit = Post.limit(5)
+    posts_with_limit_one = Post.limit(1)
 
-    assert_predicate posts, :many?
-    assert_not_predicate posts.limit(1), :many?
+    assert_predicate posts_with_limit, :many?
+    assert_not_predicate posts_with_limit, :loaded?
+
+    assert_not_predicate posts_with_limit_one, :many?
+    assert_not_predicate posts_with_limit_one, :loaded?
   end
 
   def test_none?


### PR DESCRIPTION
### Summary

In this PR, we enhance the `one?` and `many?` methods to avoid doing an in-memory count of records when the limit is present.

